### PR TITLE
Made navbar opaque

### DIFF
--- a/app/assets/stylesheets/homepage.css.scss
+++ b/app/assets/stylesheets/homepage.css.scss
@@ -42,7 +42,8 @@ body.homepage {
   
   .navbar {
     
-    background-color: rgba(255,255,255,0.8);	
+    opacity: 1.0;
+    background-color: rgb(198,218,196);	
 
     a, .navbar-toggle {
     	color: #503e2b;


### PR DESCRIPTION
Resolves #138 

@PaulJRobinson Take a look at this branch. I've used a light green to match as close as possible the semi-transparent look while being opaque. Pure white looked too much.
