### PR TITLE
Make confirmation token read-only in rails_admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,14 @@ class User < ActiveRecord::Base
   #validates :address_region  , :presence => true
   validates :address_postcode, :presence => true
 
+  rails_admin do
+    edit do
+      configure :confirmation_token do
+        read_only true
+      end
+    end
+  end
+
   def subscribed?
     subscriptions.active.present?
   end


### PR DESCRIPTION
So that we don't set it to an empty string each time and hit the uniqueness constraint.  Fixes #163 
