### PR TITLE
Make Organic Food Federation logo clickable

### DIFF
--- a/app/views/layouts/_top_nav.html.erb
+++ b/app/views/layouts/_top_nav.html.erb
@@ -1,6 +1,6 @@
 <div class="off">
 <div align="left">
-  <%= image_tag 'OFF_Logo_circle_web.gif', :class => 'img-responsive' %>
+  <%= link_to (image_tag 'OFF_Logo_circle_web.gif'), 'http://www.orgfoodfed.com/' %>
 </div>
 </div>
 <div class="social">


### PR DESCRIPTION
I had to remove the `img-responsive` class to get this to work (in chrome at least). I don’t think that class actually affected this image, though, so maybe that’s fine?

Fixes #246.
